### PR TITLE
Implement Primary-Replica Replication System

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ TEST_BIN_DIR = $(BIN_DIR)/tests
 
 # Source file handling
 SRC = $(wildcard $(SRC_DIR)/*.c)
-OBJ = $(SRC:$(SRC_DIR)/%.c=$(OBJ_DIR)/%.o)
+OBJ = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SRC))
 EXECUTABLE = $(BIN_DIR)/crimsoncache
 
 # Test file handling

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ PING
 +PONG
 ```
 
-### Method 1: Using Telnet
+### Method 2: Using Telnet
 
 ```bash
 telnet localhost 6379

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 #include "commands.h"
 #include "persistence.h"
+#include "replication.h"
 #include <string.h>
 #include <strings.h>
 #include <ctype.h>
@@ -9,6 +10,12 @@
 #include <unistd.h>
 #include <time.h>
 #include <sys/time.h>
+#include <arpa/inet.h>
+#include <pthread.h>
+#include "crimsoncache.h"
+
+extern void track_command_change(void);
+extern volatile sig_atomic_t server_running;
 
 // fallback implementations if not available
 #ifndef HAVE_STRDUP
@@ -45,6 +52,10 @@ static command_def commands[] = {
     {"ttl", ttl_command, 2, 2},
     {"save", save_command, 1, 1},
     {"bgsave", bgsave_command, 1, 1},
+    {"replicaof", replicaof_command, 3, 3},
+    {"role", role_command, 1, 1},
+    {"incr", incr_command, 2, 2},
+    {"replconf", replconf_command, 2, -1},
     {NULL, NULL, 0, 0}  // sentinel to mark end of array
 };
 
@@ -219,12 +230,30 @@ cmd_result execute_command(int client_sock, char *input, dict *db) {
         result = CMD_ERR;
     }
 
-    // track changes for write commands 
+    // track changes for write commands and propagate to replicas if needed
     if (result == CMD_OK && (
         strcasecmp(argv[0], "set") == 0 ||
         strcasecmp(argv[0], "del") == 0 ||
-        strcasecmp(argv[0], "expire") == 0)) {
+        strcasecmp(argv[0], "expire") == 0 ||
+        strcasecmp(argv[0], "incr") == 0)) {
+        
         track_command_change();
+        
+        // propagate to replicas if we're a primary and this is a client command
+        if (server_repl.role == ROLE_PRIMARY && client_sock >= 0) {
+            // ensure the command ends with \r\n for proper processing
+            char *propagate_cmd;
+            if (input[strlen(input)-1] != '\n') {
+                propagate_cmd = malloc(strlen(input) + 3);
+                if (propagate_cmd) {
+                    sprintf(propagate_cmd, "%s\r\n", input);
+                    replication_feed_slaves(propagate_cmd, strlen(propagate_cmd));
+                    free(propagate_cmd);
+                }
+            } else {
+                replication_feed_slaves(input, strlen(input));
+            }
+        }
     }
     
     free_tokens(argv, argc);
@@ -438,3 +467,172 @@ cmd_result bgsave_command(int client_sock, int argc, char **argv, dict *db) {
         return CMD_ERR;
     }
 }
+
+// replicaof command - configure server as replica of another or as primary
+cmd_result replicaof_command(int client_sock, int argc, char **argv, dict *db) {
+    (void)argc; // unused
+    (void)db;   // unused
+
+    // replicaof no one = become primary
+    if (strcasecmp(argv[1], "NO") == 0 && strcasecmp(argv[2], "ONE") == 0) {
+        replication_unset_primary();
+        reply_string(client_sock, "OK");
+        return CMD_OK;
+    }
+
+    // replicaof host port = become replica
+    const char *host = argv[1];
+    int port = atoi(argv[2]);
+    
+    if (port <= 0 || port > 65535) {
+        reply_error(client_sock, "ERR invalid port");
+        return CMD_ERR;
+    }
+    
+    if (replication_set_primary(host, port)) {
+        reply_string(client_sock, "OK");
+        return CMD_OK;
+    } else {
+        reply_error(client_sock, "ERR couldn't connect to primary");
+        return CMD_ERR;
+    }
+}
+
+// role command - return role of server (primary or replica)
+cmd_result role_command(int client_sock, int argc, char **argv, dict *db) {
+    (void)argc; // unused
+    (void)argv; // unused
+    (void)db;   // unused
+    
+    char response[1024];
+    
+    if (server_repl.role == ROLE_PRIMARY) {
+        // format: *3\r\n$6\r\nmaster\r\n:<repl_offset>\r\n*<num_replicas>\r\n...
+        int written = snprintf(response, sizeof(response), 
+                              "*3\r\n$6\r\nmaster\r\n:%lu\r\n*%d\r\n", 
+                              server_repl.repl_offset, 
+                              count_replicas());
+        
+        // add replica info
+        pthread_mutex_lock(&server_repl.replicas_mutex);
+        replica_t *curr = server_repl.replicas;
+        while (curr && written < (int)sizeof(response) - 100) {
+            written += snprintf(response + written, sizeof(response) - written,
+                              "*3\r\n$%zu\r\n%s\r\n:%d\r\n:%ld\r\n",
+                              strlen(curr->ip), curr->ip, curr->port,
+                              time(NULL) - curr->last_ack_time);
+            curr = curr->next;
+        }
+        pthread_mutex_unlock(&server_repl.replicas_mutex);
+        
+    } else {
+        // format: *5\r\n$5\r\nslave\r\n$<host_len>\r\n<host>\r\n:<port>\r\n$<state_len>\r\n<state>\r\n:<offset>\r\n
+        snprintf(response, sizeof(response),
+                "*5\r\n$5\r\nslave\r\n$%zu\r\n%s\r\n:%d\r\n$%zu\r\n%s\r\n:%lu\r\n",
+                strlen(server_repl.primary_host), server_repl.primary_host,
+                server_repl.primary_port,
+                strlen(server_repl.state == REPL_STATE_CONNECTED ? "connected" : "connecting"),
+                server_repl.state == REPL_STATE_CONNECTED ? "connected" : "connecting",
+                server_repl.repl_offset);
+    }
+    
+    write(client_sock, response, strlen(response));
+    return CMD_OK;
+}
+
+// INCR command implementation
+cmd_result incr_command(int client_sock, int argc, char **argv, dict *db) {
+    (void)argc; // unused parameter
+    
+    const char *key = argv[1];
+    
+    // Get current value
+    cc_obj *obj = dict_get(db, key);
+    long long value = 0;
+    
+    if (obj) {
+        // Key exists, check if it's a string we can convert to number
+        if (obj->type != CC_STRING) {
+            reply_error(client_sock, "ERR value is not an integer or out of range");
+            return CMD_ERR;
+        }
+        
+        // Try to parse as integer
+        char *endptr;
+        value = strtoll((char*)obj->ptr, &endptr, 10);
+        
+        if (*endptr != '\0') {
+            reply_error(client_sock, "ERR value is not an integer or out of range");
+            return CMD_ERR;
+        }
+    }
+    
+    // Increment the value
+    value++;
+    
+    // Convert back to string
+    char new_val[32];
+    snprintf(new_val, sizeof(new_val), "%lld", value);
+    
+    // Create new object
+    cc_obj *new_obj = malloc(sizeof(cc_obj));
+    if (!new_obj) {
+        reply_error(client_sock, "ERR out of memory");
+        return CMD_ERR;
+    }
+    
+    new_obj->ptr = strdup(new_val);
+    if (!new_obj->ptr) {
+        free(new_obj);
+        reply_error(client_sock, "ERR out of memory");
+        return CMD_ERR;
+    }
+    
+    new_obj->type = CC_STRING;
+    new_obj->expire = obj ? obj->expire : 0; // Preserve expiry if exists
+    new_obj->size = strlen(new_val) + 1;
+    new_obj->last_access = current_time_ms();
+    
+    if (dict_add(db, key, new_obj)) {
+        reply_integer(client_sock, value);
+        return CMD_OK;
+    } else {
+        free(new_obj->ptr);
+        free(new_obj);
+        reply_error(client_sock, "ERR could not set key");
+        return CMD_ERR;
+    }
+}
+
+// implement the REPLCONF command handler
+cmd_result replconf_command(int client_sock, int argc, char **argv, dict *db) {
+    (void)db; // unused
+    
+    // handle REPLCONF listening-port <port>
+    if (argc >= 3 && strcasecmp(argv[1], "listening-port") == 0) {
+        int port = atoi(argv[2]);
+        
+        printf("Received REPLCONF listening-port %d from replica\n", port);
+        
+        // get client IP address
+        struct sockaddr_in addr;
+        socklen_t addr_len = sizeof(addr);
+        getpeername(client_sock, (struct sockaddr*)&addr, &addr_len);
+        char ip[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &addr.sin_addr, ip, INET_ADDRSTRLEN);
+        
+        // add replica to the list (which will perform initial sync)
+        add_replica(client_sock, ip, port);
+        
+        reply_string(client_sock, "OK");
+        return CMD_OK;
+    }
+    
+    // handle other REPLCONF commands
+    reply_string(client_sock, "OK");
+    return CMD_OK;
+}
+
+
+
+

--- a/src/commands.h
+++ b/src/commands.h
@@ -51,5 +51,9 @@ cmd_result expire_command(int client_sock, int argc, char **argv, dict *db);
 cmd_result ttl_command(int client_sock, int argc, char **argv, dict *db);
 cmd_result save_command(int client_sock, int argc, char **argv, dict *db);
 cmd_result bgsave_command(int client_sock, int argc, char **argv, dict *db);
+cmd_result replicaof_command(int client_sock, int argc, char **argv, dict *db);
+cmd_result role_command(int client_sock, int argc, char **argv, dict *db);
+cmd_result incr_command(int client_sock, int argc, char **argv, dict *db);
+cmd_result replconf_command(int client_sock, int argc, char **argv, dict *db);
 
 #endif /* COMMANDS_H */

--- a/src/main.c
+++ b/src/main.c
@@ -1,3 +1,4 @@
+#define _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,14 +9,25 @@
 #include <arpa/inet.h> 
 #include <pthread.h> // POSIX threads for concurrency 
 #include <time.h> // for time-related functions
+#include <errno.h>
+#include <strings.h>  // For strcasecmp
 #include "crimsoncache.h"
 #include "commands.h"
 #include "persistence.h"
+#include "replication.h"
+
+
+// function prototypes for background threads
+void *cleanup_expired_keys(void *arg);
+void *auto_save_thread(void *arg);
+void *replication_thread(void *arg);
+void track_command_change(void);
 
 // global dictionary (server database)
 dict *server_db = NULL;
 
 volatile sig_atomic_t server_running = 1;
+
 
 // persistence-related global variables
 struct {
@@ -29,36 +41,30 @@ struct {
     .save_after_changes = 1000,  // save after 1000 changes
     .save_after_seconds = 300    // save every 5 minutes
 };
-
-void handle_signal(int sig) { //signal handler - handles ctrl+c or kill 
+void handle_signal(int sig) {
     if (sig == SIGINT || sig == SIGTERM) {
-        printf("\nShutting down server...\n");
+        printf("\nshutting down server...\n");
         server_running = 0;
     }
 }
-
+// thread to clean expired keys from database
 void *cleanup_expired_keys(void *arg) {
-    (void)arg;  // explicitly mark parameter as unused
+    (void)arg; // unused parameter
     
     while (server_running) {
-        // clean expired keys every second
         dict_clear_expired(server_db);
-        sleep(1);
+        sleep(1); // check every second
     }
+    
     return NULL;
 }
 
-// function to track changes when commands are executed
-void track_command_change() {
-    server_persistence.changes_since_save++;
-}
-
-// function to periodically check if we need to save
+// thread to auto-save the database
 void *auto_save_thread(void *arg) {
-    (void)arg;  // unused parameter
+    (void)arg; // unused parameter
     
     while (server_running) {
-        sleep(1);  // check every second
+        sleep(1); // check every second
         
         time_t now = time(NULL);
         int time_since_save = now - server_persistence.last_save;
@@ -79,6 +85,71 @@ void *auto_save_thread(void *arg) {
     return NULL;
 }
 
+// thread to handle replication tasks
+void *replication_thread(void *arg) {
+    (void)arg; // unused parameter
+    
+    while (server_running) {
+        // handle replica duties
+        if (server_repl.role == ROLE_REPLICA) {
+            // process data from primary if in connected state
+            if (server_repl.state == REPL_STATE_CONNECTED || 
+                server_repl.state == REPL_STATE_SYNC) {
+                
+                char buffer[BUFFER_SIZE];
+                int bytes_read = recv(server_repl.primary_fd, buffer, BUFFER_SIZE - 1, 0);
+                
+                if (bytes_read > 0) {
+                    buffer[bytes_read] = '\0';
+                    
+                    // process commands from primary
+                    execute_command(-1, buffer, server_db); // -1 fd means don't send response
+                    
+                    // update replication state
+                    server_repl.repl_offset += bytes_read;
+                    
+                    // if we were in sync state, move to connected
+                    if (server_repl.state == REPL_STATE_SYNC) {
+                        server_repl.state = REPL_STATE_CONNECTED;
+                        printf("replication: connected to primary\n");
+                    }
+                } 
+                else if (bytes_read == 0 || 
+                        (bytes_read < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+                    // connection closed or error
+                    printf("replication: connection to primary lost\n");
+                    close(server_repl.primary_fd);
+                    server_repl.primary_fd = -1;
+                    server_repl.state = REPL_STATE_CONNECTING;
+                    
+                    // try to reconnect after a delay
+                    sleep(1);
+                    replication_set_primary(server_repl.primary_host, server_repl.primary_port);
+                }
+            }
+            // if in connecting state, attempt to connect
+            else if (server_repl.state == REPL_STATE_CONNECTING) {
+                if (server_repl.primary_fd == -1) {
+                    replication_set_primary(server_repl.primary_host, server_repl.primary_port);
+                }
+                sleep(1); // avoid busy waiting
+            }
+        }
+        
+        // sleep to avoid busy waiting (use standard sleep instead of usleep)
+        struct timespec ts = {0, 100000000}; // 100ms
+        nanosleep(&ts, NULL);
+    }
+    
+    return NULL;
+}
+
+// track changes for persistence
+void track_command_change(void) {
+    server_persistence.changes_since_save++;
+}
+
+// handles client connections
 void *handle_client(void *arg) {
     client_t *client = (client_t *)arg;
     int client_sock = client->socket;
@@ -86,13 +157,13 @@ void *handle_client(void *arg) {
     char client_addr[INET_ADDRSTRLEN];
     
     inet_ntop(AF_INET, &client->address.sin_addr, client_addr, INET_ADDRSTRLEN);
-    printf("New client connected: %s:%d\n", 
+    printf("new client connected: %s:%d\n", 
            client_addr, ntohs(client->address.sin_port));
     
     while (server_running) {
         int bytes_read = recv(client_sock, buffer, BUFFER_SIZE - 1, 0);
         if (bytes_read <= 0) {
-            printf("Client %s:%d disconnected\n", 
+            printf("client %s:%d disconnected\n", 
                    client_addr, ntohs(client->address.sin_port));
             break;
         }
@@ -101,9 +172,6 @@ void *handle_client(void *arg) {
         
         // process command using the command module
         execute_command(client_sock, buffer, server_db);
-        
-        // track changes for persistence
-        track_command_change();
     }
     
     close(client_sock);
@@ -124,16 +192,15 @@ concurrency_model_t parse_concurrency_model(int argc, char *argv[]) {
     return CONCURRENCY_THREADED;
 }
 
-// function to run threaded server
-void run_threaded_server() {
+// function to run threaded server with custom port
+void run_threaded_server(int port) {
     int server_sock, client_sock;
     struct sockaddr_in6 server_addr;
     struct sockaddr_in client_addr;
     socklen_t client_len = sizeof(client_addr);
-    int port = DEFAULT_PORT;
     pthread_t thread_id;
     
-    // handle command line args for port
+    // now using the provided port parameter
     printf("CrimsonCache starting on port %d\n", port);
     
     // set up signal handling
@@ -191,6 +258,13 @@ void run_threaded_server() {
         perror("failed to create auto-save thread");
     }
     
+    // Start replication thread
+    pthread_t repl_thread;
+    if (pthread_create(&repl_thread, NULL, replication_thread, NULL) != 0) {
+        perror("failed to create replication thread");
+        // Non-fatal, continue
+    }
+    
     // accept connections and handle clients
     while (server_running) {
         client_sock = accept(server_sock, (struct sockaddr *)&client_addr, &client_len);
@@ -231,28 +305,43 @@ void run_eventloop_server() {
 int main(int argc, char *argv[]) {
     // initialize server database
     server_db = dict_create(1024);
-    server_persistence.last_save = time(NULL);
     if (!server_db) {
-        fprintf(stderr, "Failed to create server database\n");
+        fprintf(stderr, "failed to create server database\n");
         return EXIT_FAILURE;
     }
     
+    // initialize last_save time to current time
+    server_persistence.last_save = time(NULL);
+    
+    // initialize replication
+    replication_init();
+    
     // load data from rdb file if it exists
     if (!load_rdb_from_file(server_db, "dump.rdb")) {
-        fprintf(stderr, "Warning: could not load RDB file, starting with empty DB\n");
+        fprintf(stderr, "warning: could not load rdb file, starting with empty db\n");
+    }
+    
+    // parse port from command line args
+    int port = DEFAULT_PORT;
+    for (int i = 1; i < argc - 1; i++) {
+        if (strcmp(argv[i], "--port") == 0 || strcmp(argv[i], "-p") == 0) {
+            port = atoi(argv[i + 1]);
+            break;
+        }
     }
     
     // parse command line args for model selection
     concurrency_model_t model = parse_concurrency_model(argc, argv);
     
     if (model == CONCURRENCY_THREADED) {
-        run_threaded_server();
+        run_threaded_server(port);  // pass the port 
     } else {
         run_eventloop_server();
     }
     
     // clean up
     dict_free(server_db);
+    replication_cleanup();
     
     return 0;
 }

--- a/src/replication.c
+++ b/src/replication.c
@@ -1,0 +1,385 @@
+#define _POSIX_C_SOURCE 200809L
+#include "replication.h"
+#include "persistence.h"
+#include "commands.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <time.h>
+#include <sys/time.h>
+#include "crimsoncache.h"
+
+extern dict *server_db;
+
+// get current time in milliseconds
+static uint64_t current_time_ms() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (uint64_t)(tv.tv_sec) * 1000 + (tv.tv_usec / 1000);
+}
+
+replication_info_t server_repl;
+
+// initialize replication
+void replication_init(void) {
+    server_repl.role = ROLE_PRIMARY;
+    server_repl.state = REPL_STATE_NONE;
+    server_repl.primary_fd = -1;
+    server_repl.replicas = NULL;
+    
+    // generate a random replication id (40 chars)
+    srand(time(NULL));
+    for (int i = 0; i < 40; i++) {
+        char c = rand() % 36;
+        server_repl.replid[i] = (c < 10) ? c + '0' : c - 10 + 'a';
+    }
+    server_repl.replid[40] = '\0';
+    
+    server_repl.repl_offset = 0;
+    pthread_mutex_init(&server_repl.replicas_mutex, NULL);
+}
+
+// Add this function after add_replica()
+void sync_replica(int fd) {
+    printf("performing initial sync with replica\n");
+    
+    // create a temporary buffer to hold commands
+    char cmd_buffer[1024];
+    int success_count = 0, error_count = 0;
+    
+    // iterate through all keys and send SET commands for each one
+    for (size_t i = 0; i < server_db->size; i++) {
+        dict_entry *entry = server_db->table[i];
+        while (entry) {
+            // skip expired keys
+            if (entry->val->expire != 0 && entry->val->expire < current_time_ms()) {
+                entry = entry->next;
+                continue;
+            }
+            
+            // only handle string values for now
+            if (entry->val->type == CC_STRING) {
+                // format a SET command
+                snprintf(cmd_buffer, sizeof(cmd_buffer), 
+                         "SET %s %s\r\n", 
+                         entry->key, 
+                         (char*)entry->val->ptr);
+                
+                // add debug logging
+                printf("syncing key: [%s] with value: [%s]\n", entry->key, (char*)entry->val->ptr);
+                
+                // send to the replica
+                if (write(fd, cmd_buffer, strlen(cmd_buffer)) != (ssize_t)strlen(cmd_buffer)) {
+                    // write error - replica might be disconnected
+                    printf("error syncing key %s to replica\n", entry->key);
+                    error_count++;
+                } else {
+                    success_count++;
+                }
+                
+                // give the replica time to process the command
+                struct timespec ts = {0, 10000000};  // 10ms (0.01s) = 10,000,000 nanoseconds
+                nanosleep(&ts, NULL);  // 10ms delay between commands
+                
+                // if this key has an expiration, send EXPIRE command too
+                if (entry->val->expire != 0) {
+                    uint64_t now = current_time_ms();
+                    if (entry->val->expire > now) {
+                        // calculate remaining TTL in seconds
+                        long ttl_sec = (entry->val->expire - now) / 1000;
+                        if (ttl_sec > 0) {
+                            snprintf(cmd_buffer, sizeof(cmd_buffer), 
+                                     "EXPIRE %s %ld\r\n", 
+                                     entry->key, ttl_sec);
+                            write(fd, cmd_buffer, strlen(cmd_buffer));
+                            nanosleep(&ts, NULL);  // 10ms delay
+                        }
+                    }
+                }
+            }
+            
+            entry = entry->next;
+        }
+    }
+    
+    printf("initial sync completed: %d keys synced, %d errors\n", 
+           success_count, error_count);
+}
+
+// add a new replica to the linked list
+void add_replica(int fd, const char *ip, int port) {
+    replica_t *replica = malloc(sizeof(replica_t));
+    if (!replica) return;
+    
+    replica->fd = fd;
+    replica->ip = strdup(ip);
+    replica->port = port;
+    replica->last_ack_time = time(NULL);
+    
+    pthread_mutex_lock(&server_repl.replicas_mutex);
+    replica->next = server_repl.replicas;
+    server_repl.replicas = replica;
+    pthread_mutex_unlock(&server_repl.replicas_mutex);
+    
+    printf("new replica connected: %s:%d\n", ip, port);
+    
+    // perform initial synchronization
+    sync_replica(fd);
+}
+
+// // Handle REPLCONF command
+// cmd_result replconf_command(int client_sock, int argc, char **argv, dict *db) {
+//     (void)db; // Unused
+    
+//     // Handle REPLCONF listening-port <port>
+//     if (argc >= 3 && strcasecmp(argv[1], "listening-port") == 0) {
+//         int port = atoi(argv[2]);
+        
+//         // Get client IP address
+//         struct sockaddr_in addr;
+//         socklen_t addr_len = sizeof(addr);
+//         getpeername(client_sock, (struct sockaddr*)&addr, &addr_len);
+//         char ip[INET_ADDRSTRLEN];
+//         inet_ntop(AF_INET, &addr.sin_addr, ip, INET_ADDRSTRLEN);
+        
+//         printf("Received REPLCONF from %s:%d\n", ip, port);
+        
+//         // Add replica to the list (this will also trigger sync_replica)
+//         add_replica(client_sock, ip, port);
+        
+//         reply_string(client_sock, "OK");
+//         return CMD_OK;
+//     }
+    
+//     // Handle other REPLCONF commands
+//     reply_string(client_sock, "OK");
+//     return CMD_OK;
+// }
+
+// remove a replica from the linked list
+void remove_replica(int fd) {
+    pthread_mutex_lock(&server_repl.replicas_mutex);
+    
+    replica_t *curr = server_repl.replicas;
+    replica_t *prev = NULL;
+    
+    while (curr) {
+        if (curr->fd == fd) {
+            if (prev) {
+                prev->next = curr->next;
+            } else {
+                server_repl.replicas = curr->next;
+            }
+            
+            printf("replica disconnected: %s:%d\n", curr->ip, curr->port);
+            free(curr->ip);
+            free(curr);
+            break;
+        }
+        
+        prev = curr;
+        curr = curr->next;
+    }
+    
+    pthread_mutex_unlock(&server_repl.replicas_mutex);
+}
+
+// set this server as a replica of the specified primary
+int replication_set_primary(const char *host, int port) {
+    // clean up any existing replica connection
+    if (server_repl.primary_fd != -1) {
+        close(server_repl.primary_fd);
+        server_repl.primary_fd = -1;
+    }
+    
+    // update server role and primary info
+    server_repl.role = ROLE_REPLICA;
+    strncpy(server_repl.primary_host, host, sizeof(server_repl.primary_host) - 1);
+    server_repl.primary_port = port;
+    server_repl.state = REPL_STATE_CONNECTING;
+    
+    // resolve primary hostname
+    struct addrinfo hints, *servinfo;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    
+    char port_str[16];
+    snprintf(port_str, sizeof(port_str), "%d", port);
+    
+    int rv = getaddrinfo(host, port_str, &hints, &servinfo);
+    if (rv != 0) {
+        fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(rv));
+        return 0;
+    }
+    
+    // connect to primary
+    int fd = -1;
+    struct addrinfo *p;
+    for (p = servinfo; p != NULL; p = p->ai_next) {
+        fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+        if (fd == -1) continue;
+        
+        if (connect(fd, p->ai_addr, p->ai_addrlen) == -1) {
+            close(fd);
+            continue;
+        }
+        
+        break;
+    }
+    
+    freeaddrinfo(servinfo);
+    
+    if (p == NULL) {
+        fprintf(stderr, "failed to connect to primary %s:%d\n", host, port);
+        return 0;
+    }
+    
+    // set socket to non-blocking
+    int flags = fcntl(fd, F_GETFL, 0);
+    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    
+    server_repl.primary_fd = fd;
+    server_repl.state = REPL_STATE_SYNC;
+    
+    // send replication command to primary
+    char *cmd = "REPLCONF listening-port 6379\r\n";
+    write(fd, cmd, strlen(cmd));
+    
+    // send PSYNC command to request full resync
+    char psync_cmd[256];
+    snprintf(psync_cmd, sizeof(psync_cmd), "PSYNC ? -1\r\n");
+    write(fd, psync_cmd, strlen(psync_cmd));
+    
+    printf("connected to primary %s:%d\n", host, port);
+    return 1;
+}
+
+// disconnect from primary
+void replication_unset_primary(void) {
+    if (server_repl.primary_fd != -1) {
+        close(server_repl.primary_fd);
+        server_repl.primary_fd = -1;
+    }
+    
+    server_repl.role = ROLE_PRIMARY;
+    server_repl.state = REPL_STATE_NONE;
+    printf("disconnected from primary, now acting as primary\n");
+}
+
+// propagate commands to replicas
+void replication_feed_slaves(char *cmd, size_t cmd_len) {
+    if (server_repl.role != ROLE_PRIMARY) return;
+    
+    // Format cmd in RESP format if needed (client commands are already in text format)
+    // This implementation assumes cmd is already in the right format
+    
+    pthread_mutex_lock(&server_repl.replicas_mutex);
+    
+    replica_t *curr = server_repl.replicas;
+    replica_t *next;
+    
+    while (curr) {
+        next = curr->next; // Save next pointer in case we remove this replica
+        
+        ssize_t nwritten = write(curr->fd, cmd, cmd_len);
+        if (nwritten != (ssize_t)cmd_len) {
+            if (nwritten == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                // Would block, try again later
+                fprintf(stderr, "Would block writing to replica (will retry)\n");
+            } else {
+                // Error or connection closed, remove replica
+                fprintf(stderr, "Error writing to replica, removing it\n");
+                remove_replica(curr->fd);
+            }
+        } else {
+            // Update replication offset
+            server_repl.repl_offset += cmd_len;
+            curr->last_ack_time = time(NULL);
+        }
+        
+        curr = next;
+    }
+    
+    pthread_mutex_unlock(&server_repl.replicas_mutex);
+}
+
+// get replication info for the INFO command
+void replication_info_append(char *info, size_t *len) {
+    char buf[1024];
+    // int n;
+    
+    snprintf(buf, sizeof(buf),
+                "# Replication\r\n"
+                "role:%s\r\n"
+                "connected_replicas:%d\r\n"
+                "repl_offset:%lu\r\n"
+                "repl_id:%s\r\n",
+                replication_get_role_name(),
+                count_replicas(),
+                server_repl.repl_offset,
+                server_repl.replid);
+    
+    strncat(info, buf, *len - strlen(info) - 1);
+    
+    if (server_repl.role == ROLE_REPLICA) {
+        snprintf(buf, sizeof(buf),
+                    "primary_host:%s\r\n"
+                    "primary_port:%d\r\n"
+                    "primary_link_status:%s\r\n",
+                    server_repl.primary_host,
+                    server_repl.primary_port,
+                    server_repl.state == REPL_STATE_CONNECTED ? "up" : "down");
+        
+        strncat(info, buf, *len - strlen(info) - 1);
+    }
+}
+
+// get server role as string
+const char* replication_get_role_name(void) {
+    return server_repl.role == ROLE_PRIMARY ? "master" : "slave";
+}
+
+// count number of connected replicas
+int count_replicas(void) {
+    int count = 0;
+    pthread_mutex_lock(&server_repl.replicas_mutex);
+    
+    replica_t *curr = server_repl.replicas;
+    while (curr) {
+        count++;
+        curr = curr->next;
+    }
+    
+    pthread_mutex_unlock(&server_repl.replicas_mutex);
+    return count;
+}
+
+// clean up replication resources
+void replication_cleanup(void) {
+    // close primary connection if we're a replica
+    if (server_repl.primary_fd != -1) {
+        close(server_repl.primary_fd);
+    }
+    
+    // free all replica structures
+    pthread_mutex_lock(&server_repl.replicas_mutex);
+    
+    replica_t *curr = server_repl.replicas;
+    while (curr) {
+        replica_t *next = curr->next;
+        close(curr->fd);
+        free(curr->ip);
+        free(curr);
+        curr = next;
+    }
+    server_repl.replicas = NULL;
+    
+    pthread_mutex_unlock(&server_repl.replicas_mutex);
+    pthread_mutex_destroy(&server_repl.replicas_mutex);
+}

--- a/src/replication.h
+++ b/src/replication.h
@@ -1,0 +1,83 @@
+#ifndef REPLICATION_H
+#define REPLICATION_H
+
+#include "dict.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <pthread.h>
+
+// replication roles
+typedef enum {
+    ROLE_PRIMARY,
+    ROLE_REPLICA
+} server_role_t;
+
+// replica state
+typedef enum {
+    REPL_STATE_NONE,           // not a replica
+    REPL_STATE_CONNECTING,     // connecting to primary
+    REPL_STATE_SYNC,           // performing initial sync
+    REPL_STATE_CONNECTED       // connected and receiving updates
+} replica_state_t;
+
+// replica info
+typedef struct replica {
+    int fd;                     // socket file descriptor
+    char *ip;                   // ip address
+    int port;                   // port
+    time_t last_ack_time;       // last time replica acknowledged a command
+    struct replica *next;       // next replica in linked list
+} replica_t;
+
+// replication info
+typedef struct {
+    server_role_t role;          // current server role
+    char primary_host[256];      // primary hostname
+    int primary_port;            // primary port
+    replica_state_t state;       // state when in replica mode
+    int primary_fd;              // socket connected to primary when in replica mode
+    
+    // primary-specific fields
+    char replid[41];             // replication id
+    uint64_t repl_offset;        // replication offset
+    replica_t *replicas;         // linked list of connected replicas
+    pthread_mutex_t replicas_mutex; // mutex for thread-safe access to replicas list
+} replication_info_t;
+
+// global replication info
+extern replication_info_t server_repl;
+
+// initialize replication system
+void replication_init(void);
+
+// set this server as a replica of the specified primary
+int replication_set_primary(const char *host, int port);
+
+// disconnect from primary
+void replication_unset_primary(void);
+
+// process commands when in replica mode
+void replication_feed_slaves(char *cmd, size_t cmd_len);
+
+// get replication info for the INFO command
+void replication_info_append(char *info, size_t *len);
+
+// get server role as string
+const char* replication_get_role_name(void);
+
+// count number of connected replicas
+int count_replicas(void);
+
+// clean up replication resources
+void replication_cleanup(void);
+
+// synchronize a new replica with current data
+void sync_replica(int fd);
+
+// add a new replica to the system
+void add_replica(int fd, const char *ip, int port);
+
+// remove a replica from the system
+void remove_replica(int fd);
+
+#endif /* REPLICATION_H */


### PR DESCRIPTION
## Changes

This PR implements a primary-replica replication system, enabling CrimsonCache to run in a distributed configuration.

### New Features
- **Primary-Replica Architecture**: Servers can operate as primary (master) or replica (slave)
- **Initial Synchronization**: Full dataset is transferred when replicas connect
- **Command Propagation**: Write operations on primary are propagated to all replicas
- **Dynamic Role Configuration**: Servers can change roles at runtime via REPLICAOF
- **Fault Tolerance**: Automatic reconnection handling for network issues

### New Commands
- `REPLICAOF host port` - Configure server as replica of the specified primary
- `REPLICAOF NO ONE` - Promote a replica to primary
- `ROLE` - Return information about the server's replication role

### Implementation Details
- Non-blocking socket operations for replica connections
- Thread-safe replica list management with proper locking
- Command format preservation during propagation
- Expiration time adjustments when synchronizing keys

## Testing

Replication functionality has been manually tested:
- Primary server accepts writes and propagates to replicas
- Replicas receive initial dataset upon connection
- Command propagation works for all write operations (SET, DEL, EXPIRE, INCR)
- Reconnection works after network interruptions
- ROLE command shows proper status information