### PR TITLE
Implement Redis-Style Transactions (MULTI/EXEC/DISCARD)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -pedantic -std=c11 -g
+CFLAGS = -Wall -Wextra -pedantic  -g
 LDFLAGS = -pthread
 
 SRC_DIR = src

--- a/src/commands.h
+++ b/src/commands.h
@@ -55,5 +55,8 @@ cmd_result replicaof_command(int client_sock, int argc, char **argv, dict *db);
 cmd_result role_command(int client_sock, int argc, char **argv, dict *db);
 cmd_result incr_command(int client_sock, int argc, char **argv, dict *db);
 cmd_result replconf_command(int client_sock, int argc, char **argv, dict *db);
+cmd_result multi_command(int client_sock, int argc, char **argv, dict *db);
+cmd_result exec_command(int client_sock, int argc, char **argv, dict *db);
+cmd_result discard_command(int client_sock, int argc, char **argv, dict *db);
 
 #endif /* COMMANDS_H */

--- a/src/crimsoncache.h
+++ b/src/crimsoncache.h
@@ -16,11 +16,20 @@ typedef struct client {
     struct sockaddr_in address;
     char buffer[BUFFER_SIZE];
     int buffer_pos;
+    
+    int in_transaction;          // flag to indicate if in MULTI state
+    int transaction_errors;      // tracks if any errors occurred during MULTI
+    char **queued_commands;     
+    int queue_size;              // current size of queue
+    int queue_capacity;          // allocated capacity of queue
 } client_t;
 
 // function prototypes
 void handle_signal(int sig);
 void *handle_client(void *arg);
+void register_client(client_t *client);
+void unregister_client(client_t *client);
+client_t *get_client_by_socket(int socket);
 
 // global dictionary
 extern dict *server_db;

--- a/src/replication.c
+++ b/src/replication.c
@@ -100,7 +100,6 @@ void sync_replica(int fd) {
                 if (written == cmd_len) {
                     synced_keys++;
                     
-                    // Small delay to allow command to be processed
                     struct timespec ts = {0, 10000000}; // 10ms
                     nanosleep(&ts, NULL);
                     

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -1,0 +1,123 @@
+#define _POSIX_C_SOURCE 200809L
+#include "transaction.h"
+#include "commands.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// initialize transaction state for a client
+void tx_init(client_t *client) {
+    client->in_transaction = 0;
+    client->transaction_errors = 0;
+    client->queued_commands = NULL;
+    client->queue_size = 0;
+    client->queue_capacity = 0;
+}
+
+// clean up transaction resources
+void tx_cleanup(client_t *client) {
+    printf("Cleaning up transaction state for client %p\n", (void*)client);
+    
+    if (!client) {
+        printf("ERROR: Null client in tx_cleanup\n");
+        return;
+    }
+    
+    if (client->queued_commands) {
+        for (int i = 0; i < client->queue_size; i++) {
+            if (client->queued_commands[i]) {
+                free(client->queued_commands[i]);
+            }
+        }
+        free(client->queued_commands);
+        client->queued_commands = NULL;
+    }
+    
+    // Reset ALL transaction-related fields - CRITICAL
+    client->queue_size = 0;
+    client->queue_capacity = 0;
+    client->in_transaction = 0;      // Most important field to reset
+    client->transaction_errors = 0;
+    
+    printf("Transaction cleanup complete, in_transaction=%d\n", client->in_transaction);
+}
+
+// queue a command for later execution
+int tx_queue_command(client_t *client, char *cmd) {
+    // expand queue if needed
+    if (client->queue_size >= client->queue_capacity) {
+        int new_capacity = client->queue_capacity == 0 ? 10 : client->queue_capacity * 2;
+        char **new_queue = realloc(client->queued_commands, new_capacity * sizeof(char*));
+        if (!new_queue) {
+            return 0;  // out of memory
+        }
+        client->queued_commands = new_queue;
+        client->queue_capacity = new_capacity;
+    }
+    
+    // add debug output to see the exact command being queued
+    printf("Queueing full command: '%s'\n", cmd);
+    
+    // store the full command
+    client->queued_commands[client->queue_size] = strdup(cmd);
+    if (!client->queued_commands[client->queue_size]) {
+        return 0;  // out of memory
+    }
+    client->queue_size++;
+    return 1;
+}
+
+// execute all queued commands
+void tx_execute_commands(client_t *client, dict *db) {
+    if (client->transaction_errors) {
+        reply_error(client->socket, "EXECABORT Transaction discarded because of previous errors");
+        tx_cleanup(client);
+        return;
+    }
+    
+    int queue_size = client->queue_size;
+    printf("Executing transaction with %d commands\n", queue_size);
+    
+    char **commands = malloc(sizeof(char*) * queue_size);
+    if (!commands) {
+        reply_error(client->socket, "ERR out of memory during transaction execution");
+        tx_cleanup(client);
+        return;
+    }
+    
+    for (int i = 0; i < queue_size; i++) {
+        commands[i] = strdup(client->queued_commands[i]);
+        if (!commands[i]) {
+            for (int j = 0; j < i; j++) {
+                free(commands[j]);
+            }
+            free(commands);
+            reply_error(client->socket, "ERR out of memory during transaction execution");
+            tx_cleanup(client);
+            return;
+        }
+        printf("Command to execute: '%s'\n", commands[i]);
+    }
+    
+    char buffer[32];
+    snprintf(buffer, sizeof(buffer), "*%d\r\n", queue_size);
+    write(client->socket, buffer, strlen(buffer));
+    
+    tx_cleanup(client);
+    
+    for (int i = 0; i < queue_size; i++) {
+        printf("Executing full command: '%s'\n", commands[i]);
+        execute_command(client->socket, commands[i], db);
+        free(commands[i]);
+    }
+    
+    free(commands);
+    printf("Transaction execution complete\n");
+}
+
+// discard all queued commands
+void tx_discard_commands(client_t *client) {
+    tx_cleanup(client);
+    reply_string(client->socket, "OK");
+}

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -1,0 +1,21 @@
+#ifndef TRANSACTION_H
+#define TRANSACTION_H
+
+#include "crimsoncache.h"
+#include "dict.h"
+
+void tx_init(client_t *client);
+
+
+void tx_cleanup(client_t *client);
+
+
+int tx_queue_command(client_t *client, char *cmd);
+
+
+void tx_execute_commands(client_t *client, dict *db);
+
+
+void tx_discard_commands(client_t *client);
+
+#endif /* TRANSACTION_H */


### PR DESCRIPTION
## Changes

This PR introduces Redis-style transaction support to CrimsonCache, allowing clients to execute a sequence of commands atomically.

### New Features
- **Transaction State**: Client structures now track whether they are inside a `MULTI` block.
- **Command Queuing**: Commands issued after `MULTI` are queued rather than immediately executed.
- **Atomic Execution**: The `EXEC` command executes all queued commands in order as a single, uninterrupted operation.
- **Transaction Abort**: The `DISCARD` command clears the queue and exits the transaction state without executing any commands.
- **Error Handling**: If an error occurs while queuing commands (e.g., syntax error, out of memory), `EXEC` will abort the transaction.

### New Commands
- `MULTI`: Starts a transaction block. Subsequent commands are queued.
- `EXEC`: Executes all commands queued since `MULTI`.
- `DISCARD`: Flushes all commands queued since `MULTI` and exits the transaction state.

### Implementation Details
- Created `transaction.h` and `transaction.c` to manage transaction logic.
- Modified `execute_command` in `commands.c` to check for transaction state and queue commands accordingly.
- Ensured that the original, full command strings (including arguments) are queued and later executed.
- Implemented proper cleanup of transaction state and queued commands after `EXEC` or `DISCARD`.

## Testing
- Manually tested `MULTI`/`EXEC` with various command sequences (SET, GET, INCR).
- Verified that commands are queued and executed in the correct order.
- Confirmed that `DISCARD` correctly aborts transactions.
- Checked that the server returns to normal command processing after `EXEC` or `DISCARD`.
- Ensured that errors during the `MULTI` phase cause `EXEC` to abort.
